### PR TITLE
remove torchtext dep

### DIFF
--- a/cortex/model/root/_conv1d_root.py
+++ b/cortex/model/root/_conv1d_root.py
@@ -6,13 +6,12 @@ from typing import Optional, Union
 import numpy as np
 import torch
 from torch import LongTensor, nn
-from torchtext.transforms import PadTransform, ToTensor
 
 from cortex.corruption import CorruptionProcess, GaussianCorruptionProcess, MaskCorruptionProcess
 from cortex.model.block import Conv1dResidBlock
 from cortex.model.elemental import Apply, Expression, SinePosEncoder, permute_spatial_channel_dims
 from cortex.model.root import RootNode, RootNodeOutput
-from cortex.transforms import HuggingFaceTokenizerTransform
+from cortex.transforms import HuggingFaceTokenizerTransform, PadTransform, ToTensor
 
 
 @dataclass

--- a/cortex/transforms/__init__.py
+++ b/cortex/transforms/__init__.py
@@ -1,2 +1,4 @@
 from ._hf_tokenizer_transform import HuggingFaceTokenizerTransform
+from ._pad_transform import PadTransform
+from ._to_tensor import ToTensor
 from ._transform import Transform

--- a/cortex/transforms/_pad_transform.py
+++ b/cortex/transforms/_pad_transform.py
@@ -1,0 +1,33 @@
+# copied from https://github.com/pytorch/text/blob/main/torchtext/transforms.py
+# torchtext is no longer maintained and is incompatible with torch >= 2.4
+import torch
+from torch import Tensor
+from torch.nn import Module
+
+
+class PadTransform(Module):
+    """Pad tensor to a fixed length with given padding value.
+
+    :param max_length: Maximum length to pad to
+    :type max_length: int
+    :param pad_value: Value to pad the tensor with
+    :type pad_value: bool
+    """
+
+    def __init__(self, max_length: int, pad_value: int) -> None:
+        super().__init__()
+        self.max_length = max_length
+        self.pad_value = float(pad_value)
+
+    def forward(self, x: Tensor) -> Tensor:
+        """
+        :param x: The tensor to pad
+        :type x: Tensor
+        :return: Tensor padded up to max_length with pad_value
+        :rtype: Tensor
+        """
+        max_encoded_length = x.size(-1)
+        if max_encoded_length < self.max_length:
+            pad_amount = self.max_length - max_encoded_length
+            x = torch.nn.functional.pad(x, (0, pad_amount), value=self.pad_value)
+        return x

--- a/cortex/transforms/_to_tensor.py
+++ b/cortex/transforms/_to_tensor.py
@@ -1,0 +1,31 @@
+# copied from https://github.com/pytorch/text/blob/main/torchtext/transforms.py
+# torchtext is no longer maintained and is incompatible with torch >= 2.4
+from typing import Any, Optional
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+from torch.nn import Module
+
+
+class ToTensor(Module):
+    r"""Convert input to torch tensor
+
+    :param padding_value: Pad value to make each input in the batch of length equal to the longest sequence in the batch.
+    :type padding_value: Optional[int]
+    :param dtype: :class:`torch.dtype` of output tensor
+    :type dtype: :class:`torch.dtype`
+    """
+
+    def __init__(self, padding_value: Optional[int] = None, dtype: torch.dtype = torch.long) -> None:
+        super().__init__()
+        self.padding_value = padding_value
+        self.dtype = dtype
+
+    def forward(self, input: Any) -> Tensor:
+        """
+        :param input: Sequence or batch of token ids
+        :type input: Union[List[int], List[List[int]]]
+        :rtype: Tensor
+        """
+        return F.to_tensor(input, padding_value=self.padding_value, dtype=self.dtype)

--- a/cortex/transforms/_to_tensor.py
+++ b/cortex/transforms/_to_tensor.py
@@ -3,9 +3,10 @@
 from typing import Any, Optional
 
 import torch
-import torch.nn.functional as F
 from torch import Tensor
 from torch.nn import Module
+
+from cortex.transforms.functional import to_tensor
 
 
 class ToTensor(Module):
@@ -28,4 +29,4 @@ class ToTensor(Module):
         :type input: Union[List[int], List[List[int]]]
         :rtype: Tensor
         """
-        return F.to_tensor(input, padding_value=self.padding_value, dtype=self.dtype)
+        return to_tensor(input, padding_value=self.padding_value, dtype=self.dtype)

--- a/cortex/transforms/functional/__init__.py
+++ b/cortex/transforms/functional/__init__.py
@@ -1,5 +1,7 @@
+from ._to_tensor import to_tensor
 from ._tokenize_igg_ag_df import tokenize_igg_ag_df
 
 __all__ = [
+    "to_tensor",
     "tokenize_igg_ag_df",
 ]

--- a/cortex/transforms/functional/_to_tensor.py
+++ b/cortex/transforms/functional/_to_tensor.py
@@ -1,0 +1,31 @@
+from typing import Any, Optional
+
+import torch
+from torch import Tensor
+from torch.nn.utils.rnn import pad_sequence
+
+
+def to_tensor(input: Any, padding_value: Optional[int] = None, dtype: torch.dtype = torch.long) -> Tensor:
+    r"""Convert input to torch tensor
+
+    :param padding_value: Pad value to make each input in the batch of length equal to the longest sequence in the batch.
+    :type padding_value: Optional[int]
+    :param dtype: :class:`torch.dtype` of output tensor
+    :type dtype: :class:`torch.dtype`
+    :param input: Sequence or batch of token ids
+    :type input: Union[list[int], list[list[int]]]
+    :rtype: Tensor
+    """
+    if torch.jit.isinstance(input, list[int]):
+        return torch.tensor(input, dtype=torch.long)
+    elif torch.jit.isinstance(input, list[list[int]]):
+        if padding_value is None:
+            output = torch.tensor(input, dtype=dtype)
+            return output
+        else:
+            output = pad_sequence(
+                [torch.tensor(ids, dtype=dtype) for ids in input], batch_first=True, padding_value=float(padding_value)
+            )
+            return output
+    else:
+        raise TypeError("Input type not supported")

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,4 @@
 torch
-torchtext
 torchvision
 pytorch_warmup
 botorch >= 0.9.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -164,7 +164,6 @@ numpy==1.26.1
     #   scikit-learn
     #   scipy
     #   torchmetrics
-    #   torchtext
     #   torchvision
     #   transformers
 nvidia-cublas-cu12==12.1.3.1
@@ -275,7 +274,6 @@ requests==2.31.0
     #   lightning
     #   lightning-cloud
     #   torchdata
-    #   torchtext
     #   torchvision
     #   transformers
     #   wandb
@@ -340,7 +338,6 @@ torch==2.1.0
     #   pytorch-warmup
     #   torchdata
     #   torchmetrics
-    #   torchtext
     #   torchvision
 torchdata==0.7.0
     # via torchtext
@@ -348,8 +345,6 @@ torchmetrics==1.3.1
     # via
     #   lightning
     #   pytorch-lightning
-torchtext==0.16.0
-    # via -r requirements.in
 torchvision==0.16.0
     # via -r requirements.in
 tqdm==4.66.1
@@ -359,7 +354,6 @@ tqdm==4.66.1
     #   lightning
     #   pyro-ppl
     #   pytorch-lightning
-    #   torchtext
     #   transformers
 traitlets==5.14.1
     # via lightning


### PR DESCRIPTION
torchtext is no longer maintained and is not compatible with `torch >= 2.4`. The dependency is underutilized and so is being removed

https://github.com/prescient-design/cortex/issues/6