### PR TITLE
Add timestep sampling distribution to corruption

### DIFF
--- a/cortex/corruption/_abstract_corruption.py
+++ b/cortex/corruption/_abstract_corruption.py
@@ -17,13 +17,13 @@ class CorruptionProcess(ABC):
     """
 
     def __init__(
-            self,
-            schedule: str = "cosine",
-            max_steps: int = 1000,
-            t_base_dist: Optional[torch_dist.Distribution] = None,
-            *args,
-            **kwargs,
-        ):        
+        self,
+        schedule: str = "cosine",
+        max_steps: int = 1000,
+        t_base_dist: Optional[torch_dist.Distribution] = None,
+        *args,
+        **kwargs,
+    ):
         betas = get_named_beta_schedule(schedule, max_steps)
 
         # Use float64 for accuracy.
@@ -74,7 +74,7 @@ class CorruptionProcess(ABC):
 
         if n is None or n == 1:
             return torch.tensor([self.timestep_to_corrupt_frac(timesteps)])
-        
+
         return torch.tensor(self.timestep_to_corrupt_frac(timesteps))
 
     def timestep_to_corrupt_frac(self, timestep: Union[int, torch.Tensor]) -> float:

--- a/cortex/corruption/_abstract_corruption.py
+++ b/cortex/corruption/_abstract_corruption.py
@@ -3,6 +3,7 @@ from typing import Optional, Union
 
 import numpy as np
 import torch
+import torch.distributions as torch_dist
 
 from cortex.corruption._diffusion_noise_schedule import get_named_beta_schedule
 
@@ -15,7 +16,14 @@ class CorruptionProcess(ABC):
     the corruption interface.
     """
 
-    def __init__(self, schedule: str = "cosine", max_steps: int = 1000, *args, **kwargs):
+    def __init__(
+            self,
+            schedule: str = "cosine",
+            max_steps: int = 1000,
+            t_base_dist: Optional[torch_dist.Distribution] = None,
+            *args,
+            **kwargs,
+        ):        
         betas = get_named_beta_schedule(schedule, max_steps)
 
         # Use float64 for accuracy.
@@ -30,7 +38,14 @@ class CorruptionProcess(ABC):
         self.alphas_cumprod = np.cumprod(alphas, axis=0)
         self.sqrt_alphas_cumprod = np.sqrt(self.alphas_cumprod)
 
-    def sample_timestep(self, n: Optional[int] = None):
+        # Set up timestep sampling distribution
+        if t_base_dist is None:
+            # use Beta(5, 1) as default to preferentially sample lower noise levels
+            self.t_base_dist = torch_dist.Beta(3, 1)
+        else:
+            self.t_base_dist = t_base_dist
+
+    def sample_timestep(self, n: Optional[int] = 1):
         """Sample timestep(s) from the noise schedule.
 
         Args:
@@ -40,10 +55,8 @@ class CorruptionProcess(ABC):
         Returns:
             Int or array of timesteps.
         """
-        if n is None:
-            return np.random.randint(1, self.max_steps + 1)
-
-        return np.random.randint(1, self.max_steps + 1, size=(n,))
+        base_samples = self.t_base_dist.sample((n,))
+        return torch.round(self.max_steps * base_samples).int()
 
     def sample_corrupt_frac(self, n: Optional[int] = None) -> torch.Tensor:
         """Sample corruption fraction(s).

--- a/tests/cortex/corruption/test_mask_corruption.py
+++ b/tests/cortex/corruption/test_mask_corruption.py
@@ -64,3 +64,16 @@ def test_sample_corrupt_frac_with_n():
     more_samples = corruption_process.sample_corrupt_frac(n=100)
     assert more_samples.shape[0] == 100
     assert more_samples.unique().shape[0] > 1, "Sample corrupt_frac values should vary"
+
+def test_tdist_sampling():
+    """Test that MaskCorruptionProcess accepts and uses a provided timestep distribution."""
+    corruption_process = MaskCorruptionProcess(t_base_dist=torch.distributions.Beta(7, 1))
+
+    # Verify that different elements can have different values
+    # (This is probabilistic, but with high probability values should differ)
+    more_samples = corruption_process.sample_corrupt_frac(n=100)
+    assert more_samples.shape[0] == 100
+    assert more_samples.unique().shape[0] > 1, "Sample corrupt_frac values should vary"
+
+    # Verify that the distribution is correct
+    assert more_samples.mean() < 0.5, "Expected mean corruption to be less than 0.5"

--- a/tests/cortex/corruption/test_mask_corruption.py
+++ b/tests/cortex/corruption/test_mask_corruption.py
@@ -65,6 +65,7 @@ def test_sample_corrupt_frac_with_n():
     assert more_samples.shape[0] == 100
     assert more_samples.unique().shape[0] > 1, "Sample corrupt_frac values should vary"
 
+
 def test_tdist_sampling():
     """Test that MaskCorruptionProcess accepts and uses a provided timestep distribution."""
     corruption_process = MaskCorruptionProcess(t_base_dist=torch.distributions.Beta(7, 1))


### PR DESCRIPTION
Adds option to specify a timestep sampling distribution to corruption classes.

Previously distribution was set as uniform, which has high levels of corruption on most samples. New default is beta distribution that preferentially samples later timesteps (lower corruption.